### PR TITLE
Retrieve session token using app-bridge-utils

### DIFF
--- a/app/javascript/shopify_app/shopify_app.js
+++ b/app/javascript/shopify_app/shopify_app.js
@@ -1,6 +1,8 @@
-document.addEventListener('DOMContentLoaded', async () => {
-  var data = document.getElementById('shopify-app-init').dataset;
-  var AppBridge = window['app-bridge'];
+import { getSessionToken } from "@shopify/app-bridge-utils";
+
+document.addEventListener("DOMContentLoaded", async () => {
+  var data = document.getElementById("shopify-app-init").dataset;
+  var AppBridge = window["app-bridge"];
   var createApp = AppBridge.default;
   window.app = createApp({
     apiKey: data.apiKey,
@@ -15,7 +17,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Wait for the token before trying to load an authenticated page
   await retrieveToken(app);
-  Turbolinks.visit('/home');
+  Turbolinks.visit("/home");
 
   // Keep requesting the token every 50 seconds (I don't think we can wait for the token inline in request-start
   // event listener)
@@ -23,27 +25,22 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 
 async function retrieveToken(app) {
-  var AppBridge = window['app-bridge'];
-  app.dispatch(AppBridge.actions.SessionToken.request());
-
-  window.sessionToken = await new Promise((resolve) => {
-    app.subscribe(AppBridge.actions.SessionToken.ActionType.RESPOND, (data) => {
-      resolve(data.sessionToken || '');
-    });
-  });
+  window.sessionToken = await getSessionToken(app);
 }
 
 function keepRetrievingToken(app) {
-  setInterval(() => { retrieveToken(app) }, 50000);
+  setInterval(() => {
+    retrieveToken(app);
+  }, 50000);
 }
 
-document.addEventListener("turbolinks:request-start", function(event) {
+document.addEventListener("turbolinks:request-start", function (event) {
   var xhr = event.data.xhr;
   xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
 });
 
-document.addEventListener("turbolinks:render", function() {
-  $('form, a[data-method=delete]').on('ajax:beforeSend', function(event) {
+document.addEventListener("turbolinks:render", function () {
+  $("form, a[data-method=delete]").on("ajax:beforeSend", function (event) {
     const xhr = event.detail[0];
     xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
   });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
+    "@shopify/app-bridge-utils": "1.22.0",
     "jquery": "^3.5.1",
     "turbolinks": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,6 +839,18 @@
     webpack-cli "^3.3.10"
     webpack-sources "^1.4.3"
 
+"@shopify/app-bridge-utils@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@shopify/app-bridge-utils/-/app-bridge-utils-1.22.0.tgz#8e4c2bb2c26a04cae0a3f61ec7f8c6592f2762b6"
+  integrity sha512-XY5petRpGKQ2dS9i9ACVEt9BTzYwbvHN4Q03sRUAxOpkCJ7KWOT/u215/auqC/EdXact8U4zNfGbbTiiwpKsbA==
+  dependencies:
+    "@shopify/app-bridge" "^1.22.0"
+
+"@shopify/app-bridge@^1.22.0":
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/@shopify/app-bridge/-/app-bridge-1.23.0.tgz#7c71ae3770f354d4cc8bd5908284d66483a6f7e6"
+  integrity sha512-UTEHRv3pYYU+YOJpiLKPB8CIL73hsh0Kl+PVD0NCOu44NCHoxKe5B8g29ti/TKNs5+LerATMJfjGZuPRTNr2yA==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"


### PR DESCRIPTION
Using the preferred method of `getSessionToken` in app-bridge-utils to fetch the authenticated session token. 

Documentation for this is app can be found [here](https://github.com/Shopify/turbolinks-jwt-sample-app/pull/5).