### PR TITLE
Create controller callback to authenticate a request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,4 +51,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'shopify_app', '~> 14.0.0'
+gem 'shopify_app', '~> 16.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,12 +88,15 @@ GEM
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
-    faraday (1.0.1)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.0)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    graphql (1.11.2)
+    graphql (1.11.6)
     graphql-client (0.16.0)
       activesupport (>= 3.0)
       graphql (~> 1.8)
@@ -102,7 +105,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
-    jwt (2.2.1)
+    jwt (2.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -138,7 +141,7 @@ GEM
     omniauth-oauth2 (1.5.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.2)
-    omniauth-shopify-oauth2 (2.2.2)
+    omniauth-shopify-oauth2 (2.2.3)
       activesupport
       omniauth-oauth2 (~> 1.5.0)
     public_suffix (4.0.4)
@@ -182,6 +185,7 @@ GEM
     redirect_safely (1.0.0)
       activemodel
     regexp_parser (1.7.0)
+    ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
@@ -201,7 +205,7 @@ GEM
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack
-    shopify_app (14.0.0)
+    shopify_app (16.1.0)
       browser_sniffer (~> 1.2.2)
       jwt (~> 2.2.1)
       omniauth-shopify-oauth2 (~> 2.2.2)
@@ -258,7 +262,7 @@ DEPENDENCIES
   rails (~> 6.0.2, >= 6.0.2.2)
   sass-rails (>= 6)
   selenium-webdriver
-  shopify_app (~> 14.0.0)
+  shopify_app (~> 16.1.0)
   sqlite3 (~> 1.4)
   turbolinks (~> 5)
   tzinfo-data

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class AuthenticatedController < ApplicationController
+  include ShopifyApp::EnsureAuthenticatedLinks
   include ShopifyApp::Authenticated
-
-  before_action :shop_origin
-
-  def shop_origin
-    @shop_origin = current_shopify_domain
-  end
 end


### PR DESCRIPTION
## About this PR

It was brought to the team's attention that the Turbolinks solution does not support app deep-linking. If this is a valid use-case an embedded Shopify app has within the context of Shopify Admin, here's a suggested change that can be made to `AuthenticatedController`.

This solution works with the following cases:

1. An app has created an Admin Link App Extension that links to one of these routes/endpoints/resources/links.
1. A certain route/endpoint/resource/link is accessed in the admin (e.g `/admin/apps/{your_app}/custom_link`
    - **If this endpoint does not require authentication:** render as normal
    - I**f this endpoint requires authentication:**
        - **If the app client has a valid session token:** render the protected resource as normal
        - **If the app client does not have a valid session token:**
            1. `AuthenticatedController` redirects this page to the `SplashPageController` setting a `return_to` parameter
            1. The app client obtains a valid session token
            1. Turbolinks navigates the app client back to the `return_to` parameter set before