### PR TITLE
Remove shop on app/uninstalled webhook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'
+  gem 'mocha'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
+    mocha (1.12.0)
     msgpack (1.3.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -254,6 +255,7 @@ DEPENDENCIES
   dotenv-rails (~> 2.7.5)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  mocha
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.2)
   sass-rails (>= 6)

--- a/app/jobs/app_uninstalled_job.rb
+++ b/app/jobs/app_uninstalled_job.rb
@@ -1,0 +1,13 @@
+class AppUninstalledJob < ActiveJob::Base
+  def perform(args)
+    shop = Shop.find_by(shopify_domain: args[:shop_domain])
+
+    mark_shop_as_uninstalled(shop)
+  end
+
+  private
+
+  def mark_shop_as_uninstalled(shop)
+    shop.destroy! if shop
+  end
+end

--- a/app/jobs/register_webhooks_for_active_shops.rb
+++ b/app/jobs/register_webhooks_for_active_shops.rb
@@ -1,0 +1,19 @@
+class RegisterWebhooksForActiveShops < ApplicationJob
+  queue_as :default
+
+  def perform
+    register_webhooks_for_active_shops
+  end
+
+  private
+
+  def register_webhooks_for_active_shops
+    Shop.find_each do |shop|
+      ShopifyApp::WebhooksManagerJob.perform_now(
+        shop_domain: shop.shopify_domain,
+        shop_token: shop.shopify_token,
+        webhooks: ShopifyApp.configuration.webhooks
+      )
+    end
+  end
+end

--- a/config/initializers/shopify_app.rb
+++ b/config/initializers/shopify_app.rb
@@ -11,6 +11,9 @@ ShopifyApp.configure do |config|
   config.shop_session_repository = 'Shop'
   config.allow_jwt_authentication = true
   config.myshopify_domain = ENV['SHOPIFY_DOMAIN']
+  config.webhooks = [
+    {topic: 'app/uninstalled', address: "#{ENV['APP_URL']}/webhooks/app_uninstalled", format: 'json'},
+  ]
 end
 
 ShopifyAPI::Session.myshopify_domain = ENV['SHOPIFY_DOMAIN']

--- a/test/fixtures/shops.yml
+++ b/test/fixtures/shops.yml
@@ -1,3 +1,7 @@
 regular_shop:
   shopify_domain: 'regular-shop.myshopify.com'
   shopify_token: 'token'
+
+second_shop:
+  shopify_domain: 'second-shop.myshopify.com'
+  shopify_token: 'token2'

--- a/test/jobs/app_uninstalled_job_test.rb
+++ b/test/jobs/app_uninstalled_job_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class AppUninstalledJobTest < ActiveJob::TestCase
+  def setup
+    @shop = shops(:regular_shop)
+  end
+
+  def job
+    @job ||= ::AppUninstalledJob.new
+  end
+
+  test "AppUninstalledJob marks the shop as uninstalled from the app" do
+    job.perform(shop_domain: @shop.shopify_domain)
+
+    assert_raises ActiveRecord::RecordNotFound do
+      @shop.reload
+    end
+  end
+
+  test "AppUninstalledJob does nothing for non-existent shop" do
+    Shop.any_instance.expects(:destroy!).never
+
+    job.perform(shop_domain: 'example.myshopify.com')
+  end
+end

--- a/test/jobs/register_webhooks_for_active_shops_test.rb
+++ b/test/jobs/register_webhooks_for_active_shops_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class RegisterWebhooksForActiveShopsTest < ActiveJob::TestCase
+  def setup
+    @shop_1 = shops(:regular_shop)
+    @shop_2 = shops(:second_shop)
+  end
+
+  def job
+    @job ||= ::RegisterWebhooksForActiveShops.new
+  end
+
+
+  test "RegisterWebhooksForActiveShops registers webhooks for all existing shops" do
+    ShopifyApp::WebhooksManagerJob.expects(:perform_now).with(
+      shop_domain: @shop_1.shopify_domain,
+      shop_token: @shop_1.shopify_token,
+      webhooks: ShopifyApp.configuration.webhooks
+    ).once
+
+    ShopifyApp::WebhooksManagerJob.expects(:perform_now).with(
+      shop_domain: @shop_2.shopify_domain,
+      shop_token: @shop_2.shopify_token,
+      webhooks: ShopifyApp.configuration.webhooks
+    ).once
+
+    job.perform_now
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,9 @@
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
+require "mocha/setup"
+require 'minitest'
+require 'minitest/autorun'
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers


### PR DESCRIPTION
This PR introduces the setup for the `app/uninstalled` webhook. The app will run the `AppUninstalledJob` when an `app/uninstalled` webhook arrives and mark the shop as uninstalled.

🎩 **For new shops**
1. Run the app on production shop (ensure to go through OAuth in order for the webhook to be registered)
2. Ensure shop record exists on the app
3. Uninstall app from shop
4. Notice `app/uninstalled` webhook to be picked up on app logs and the shop record deleted

🎩 **For existing shops**
1. Run `master` branch of the app and install it on the production shop, ensuring that the webhook was not registered
2. Open a Rails console and run `RegisterWebhooksForActiveShops.perform_now` to register webhooks for all shops in the database
3. Uninstall app from shop
4. Notice `app/uninstalled` webhook to be picked up on app logs and the shop record deleted