### PR TITLE
Add responsibility of uninstall to the Shop model

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ class AppUninstalledJob < ActiveJob::Base
   private
 
   def mark_shop_as_uninstalled(shop)
-    shop.destroy! if shop
+    shop.uninstall! if shop
   end
 end
 ```

--- a/app/jobs/app_uninstalled_job.rb
+++ b/app/jobs/app_uninstalled_job.rb
@@ -8,6 +8,6 @@ class AppUninstalledJob < ActiveJob::Base
   private
 
   def mark_shop_as_uninstalled(shop)
-    shop.destroy! if shop
+    shop.uninstall! if shop
   end
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -2,6 +2,14 @@
 class Shop < ActiveRecord::Base
   include ShopifyApp::ShopSessionStorage
 
+  def uninstall
+    destroy
+  end
+
+  def uninstall!
+    destroy!
+  end
+
   def api_version
     ShopifyApp.configuration.api_version
   end

--- a/test/helpers/shop_lifecycle_test_helper.rb
+++ b/test/helpers/shop_lifecycle_test_helper.rb
@@ -1,0 +1,17 @@
+module ShopLifecycleTestHelper
+  def assert_uninstalls(shopify_domain, &block)
+    assert_difference 'Shop.count', -1, "one shop should have been uninstalled", &block
+
+    assert_nil Shop.find_by(shopify_domain: shopify_domain), "shop #{shopify_domain} is still installed"
+  end
+
+  def assert_installed(shopify_domain)
+    assert_not_nil Shop.find_by(shopify_domain: shopify_domain)
+  end
+
+  def assert_no_installation_change
+    assert_difference 'Shop.count', 0 do
+      yield
+    end
+  end
+end

--- a/test/models/shop_test.rb
+++ b/test/models/shop_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'helpers/shop_lifecycle_test_helper'
+
+class ShopTest < ActiveSupport::TestCase
+  def setup
+    @shop_1 = shops(:regular_shop)
+    @shop_2 = shops(:second_shop)
+  end
+
+  test "#uninstall marks the shop as uninstalled" do
+    @shop_1.uninstall
+
+    assert_nil Shop.find_by(shopify_domain: @shop_1.shopify_domain)
+    assert_equal @shop_2, Shop.find_by(shopify_domain: @shop_2.shopify_domain)
+  end
+
+  test "#uninstall! marks the shop as uninstalled" do
+    @shop_1.uninstall!
+
+    assert_nil Shop.find_by(shopify_domain: @shop_1.shopify_domain)
+    assert_equal @shop_2, Shop.find_by(shopify_domain: @shop_2.shopify_domain)
+  end
+end


### PR DESCRIPTION
Adding a level of indirection to indicate that the Shop model determines how a shop is to be marked as uninstalled. This can thus vary based on how the Shop model is structured.