### PR TITLE
[Prototype] Respond to redirect xhr requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
-    faraday-net_http (1.0.0)
+    faraday-net_http (1.0.1)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
-    faraday-net_http (1.0.1)
+    faraday-net_http (1.0.0)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,5 +2,6 @@
 
 class HomeController < AuthenticatedController
   def index
+    @shop_origin = current_shopify_domain
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,6 +2,7 @@
 
 class ProductsController < AuthenticatedController
   def index
-    @products = ShopifyAPI::Product.find(:all, params: { limit: 10 })
+    # @products = ShopifyAPI::Product.find(:all, params: { limit: 10 })
+    redirect_to widgets_path(request.params)
   end
 end

--- a/app/javascript/shopify_app/index.js
+++ b/app/javascript/shopify_app/index.js
@@ -1,2 +1,3 @@
 require('./shopify_app')
 require('./flash_messages')
+require('./turbolinks')

--- a/app/javascript/shopify_app/shopify_app.js
+++ b/app/javascript/shopify_app/shopify_app.js
@@ -1,53 +1,26 @@
 import { getSessionToken } from "@shopify/app-bridge-utils";
 
-document.addEventListener("DOMContentLoaded", async () => {
-  const origOpen = XMLHttpRequest.prototype.open;
+const SESSION_TOKEN_REFRESH_INTERVAL = 2000; // Request a new token every 2s
 
-  XMLHttpRequest.prototype.open = function() {
-    this.addEventListener('load', function() {
-      const parsedUrl = new URL(this.responseURL);
-      const return_to_param = parsedUrl.searchParams.get('return_to');
-
-      if (return_to_param) {
-        Turbolinks.visit(return_to_param);
-      }
-    });
-    origOpen.apply(this, arguments);
-  };
-
-  var data = document.getElementById("shopify-app-init").dataset;
-  var AppBridge = window["app-bridge"];
-  var createApp = AppBridge.default;
-  window.app = createApp({
-    apiKey: data.apiKey,
-    shopOrigin: data.shopOrigin,
-  });
-
-  var actions = AppBridge.actions;
-  var TitleBar = actions.TitleBar;
-  TitleBar.create(app, {
-    title: data.page,
-  });
+document.addEventListener("DOMContentLoaded", async function () {
+  // Initialize the Embedded App
+  initializeAppBridge();
+  initializeAppTitleBar();
 
   // Wait for a session token before trying to load an authenticated page
   await retrieveToken(app);
 
-  // Redirect to the requested page
-  Turbolinks.visit(data.loadPath);
-
   // Keep retrieving a session token periodically
   keepRetrievingToken(app);
+
+  // Redirect to the requested page when DOM loads
+  var isInitialRedirect = true;
+  redirectThroughTurbolinks(isInitialRedirect);
+
+  document.addEventListener("turbolinks:load", function (event) {
+    redirectThroughTurbolinks();
+  });
 });
-
-async function retrieveToken(app) {
-  window.sessionToken = await getSessionToken(app);
-}
-
-function keepRetrievingToken(app) {
-  setInterval(() => {
-    retrieveToken(app);
-  }, 50000);
-}
 
 document.addEventListener("turbolinks:request-start", function (event) {
   var xhr = event.data.xhr;
@@ -60,3 +33,60 @@ document.addEventListener("turbolinks:render", function () {
     xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
   });
 });
+
+// Helper functions
+
+function getShopifyAppData () {
+  return document.getElementById("shopify-app-init").dataset;
+}
+
+function redirectThroughTurbolinks(isInitialRedirect = false) {
+  var data = getShopifyAppData();
+  var validLoadPath = data && data.loadPath;
+  var shouldRedirect = false;
+
+  switch(isInitialRedirect) {
+    case true:
+      shouldRedirect = validLoadPath;
+      break;
+    case false:
+      shouldRedirect = validLoadPath && data.loadPath !== '/home'; // Replace with the app's home_path
+      break;
+  }
+
+  if (shouldRedirect) Turbolinks.visit(data.loadPath);
+}
+
+function initializeAppBridge () {
+  var data = getShopifyAppData();
+
+  var AppBridge = window["app-bridge"];
+  var createApp = AppBridge.default;
+
+  window.app = createApp({
+    apiKey: data.apiKey,
+    shopOrigin: data.shopOrigin,
+  });
+}
+
+function initializeAppTitleBar () {
+  var data = getShopifyAppData();
+
+  var AppBridge = window["app-bridge"];
+  var actions = AppBridge.actions;
+  var TitleBar = actions.TitleBar;
+
+  TitleBar.create(app, {
+    title: data.page,
+  });
+}
+
+async function retrieveToken(app) {
+  window.sessionToken = await getSessionToken(app);
+}
+
+function keepRetrievingToken(app) {
+  setInterval(() => {
+    retrieveToken(app);
+  }, SESSION_TOKEN_REFRESH_INTERVAL);
+}

--- a/app/javascript/shopify_app/shopify_app.js
+++ b/app/javascript/shopify_app/shopify_app.js
@@ -1,6 +1,20 @@
 import { getSessionToken } from "@shopify/app-bridge-utils";
 
 document.addEventListener("DOMContentLoaded", async () => {
+  const origOpen = XMLHttpRequest.prototype.open;
+
+  XMLHttpRequest.prototype.open = function() {
+    this.addEventListener('load', function() {
+      const parsedUrl = new URL(this.responseURL);
+      const return_to_param = parsedUrl.searchParams.get('return_to');
+
+      if (return_to_param) {
+        Turbolinks.visit(return_to_param);
+      }
+    });
+    origOpen.apply(this, arguments);
+  };
+
   var data = document.getElementById("shopify-app-init").dataset;
   var AppBridge = window["app-bridge"];
   var createApp = AppBridge.default;

--- a/app/javascript/shopify_app/shopify_app.js
+++ b/app/javascript/shopify_app/shopify_app.js
@@ -1,92 +1,15 @@
-import { getSessionToken } from "@shopify/app-bridge-utils";
-
-const SESSION_TOKEN_REFRESH_INTERVAL = 2000; // Request a new token every 2s
-
-document.addEventListener("DOMContentLoaded", async function () {
-  // Initialize the Embedded App
-  initializeAppBridge();
-  initializeAppTitleBar();
-
-  // Wait for a session token before trying to load an authenticated page
-  await retrieveToken(app);
-
-  // Keep retrieving a session token periodically
-  keepRetrievingToken(app);
-
-  // Redirect to the requested page when DOM loads
-  var isInitialRedirect = true;
-  redirectThroughTurbolinks(isInitialRedirect);
-
-  document.addEventListener("turbolinks:load", function (event) {
-    redirectThroughTurbolinks();
-  });
-});
-
-document.addEventListener("turbolinks:request-start", function (event) {
-  var xhr = event.data.xhr;
-  xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
-});
-
-document.addEventListener("turbolinks:render", function () {
-  $("form, a[data-method=delete]").on("ajax:beforeSend", function (event) {
-    const xhr = event.detail[0];
-    xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
-  });
-});
-
-// Helper functions
-
-function getShopifyAppData () {
-  return document.getElementById("shopify-app-init").dataset;
-}
-
-function redirectThroughTurbolinks(isInitialRedirect = false) {
-  var data = getShopifyAppData();
-  var validLoadPath = data && data.loadPath;
-  var shouldRedirect = false;
-
-  switch(isInitialRedirect) {
-    case true:
-      shouldRedirect = validLoadPath;
-      break;
-    case false:
-      shouldRedirect = validLoadPath && data.loadPath !== '/home'; // Replace with the app's home_path
-      break;
-  }
-
-  if (shouldRedirect) Turbolinks.visit(data.loadPath);
-}
-
-function initializeAppBridge () {
-  var data = getShopifyAppData();
-
-  var AppBridge = window["app-bridge"];
+document.addEventListener('DOMContentLoaded', () => {
+  var data = document.getElementById('shopify-app-init').dataset;
+  var AppBridge = window['app-bridge'];
   var createApp = AppBridge.default;
-
   window.app = createApp({
     apiKey: data.apiKey,
     shopOrigin: data.shopOrigin,
   });
-}
 
-function initializeAppTitleBar () {
-  var data = getShopifyAppData();
-
-  var AppBridge = window["app-bridge"];
   var actions = AppBridge.actions;
   var TitleBar = actions.TitleBar;
-
   TitleBar.create(app, {
     title: data.page,
   });
-}
-
-async function retrieveToken(app) {
-  window.sessionToken = await getSessionToken(app);
-}
-
-function keepRetrievingToken(app) {
-  setInterval(() => {
-    retrieveToken(app);
-  }, SESSION_TOKEN_REFRESH_INTERVAL);
-}
+});

--- a/app/javascript/shopify_app/turbolinks.js
+++ b/app/javascript/shopify_app/turbolinks.js
@@ -1,0 +1,58 @@
+import { getSessionToken } from "@shopify/app-bridge-utils";
+
+const SESSION_TOKEN_REFRESH_INTERVAL = 2000; // Request a new token every 2s
+
+document.addEventListener("turbolinks:request-start", function (event) {
+  var xhr = event.data.xhr;
+  xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
+});
+
+document.addEventListener("turbolinks:render", function () {
+  $("form, a[data-method=delete]").on("ajax:beforeSend", function (event) {
+    const xhr = event.detail[0];
+    xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
+  });
+});
+
+document.addEventListener("DOMContentLoaded", async function () {
+  // Wait for a session token before trying to load an authenticated page
+  await retrieveToken(app);
+
+  // Keep retrieving a session token periodically
+  keepRetrievingToken(app);
+
+  // Redirect to the requested page when DOM loads
+  var isInitialRedirect = true;
+  redirectThroughTurbolinks(isInitialRedirect);
+
+  document.addEventListener("turbolinks:load", function (event) {
+    redirectThroughTurbolinks();
+  });
+
+  // Helper functions
+  function redirectThroughTurbolinks(isInitialRedirect = false) {
+    var data = document.getElementById("shopify-app-init").dataset;
+    var validLoadPath = data && data.loadPath;
+    var shouldRedirect = false;
+
+    switch(isInitialRedirect) {
+      case true:
+        shouldRedirect = validLoadPath;
+        break;
+      case false:
+        shouldRedirect = validLoadPath && data.loadPath !== '/home'; // Replace with the app's home_path
+        break;
+    }
+    if (shouldRedirect) Turbolinks.visit(data.loadPath);
+  }
+
+  async function retrieveToken(app) {
+    window.sessionToken = await getSessionToken(app);
+  }
+
+  function keepRetrievingToken(app) {
+    setInterval(() => {
+      retrieveToken(app);
+    }, SESSION_TOKEN_REFRESH_INTERVAL);
+  }
+});

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,3 @@
-<%= link_to 'Products', products_path %>
+<%= link_to 'Products', products_path(shop: @shop_origin) %>
 <br>
-<%= link_to 'Widgets', widgets_path %>
+<%= link_to 'Widgets', widgets_path(shop: @shop_origin) %>


### PR DESCRIPTION
## This PR
This PR introduces a new event listener on the `DOMContentLoaded` event for `turbolinks:loaded`.

With the help of our `EnsureAuthenticatedLinks` [concern](https://github.com/Shopify/shopify_app/blob/master/app/controllers/concerns/shopify_app/ensure_authenticated_links.rb), this change fixes deeplinking on Safari. It also helps us navigate around Safari's header issues on XHR redirects.

## Things to focus on

* ~~To isolate what was happening, I had to do a quick refactor of the main `DOMContentLoaded` events listener in `shopify_app.js`~~
* ~~This refactor helped me then reuse some components, and so the shape of this file may look slightly different now (but in my opinion, is easier to read)~~
* The key change here was the introduction of a `turbolinks:load` event listener installed within the DCL event.
* This PR moves the contents of `shopify_app.js` back to the default shape of the file that is generated by Shopify App today
* This PR introduces a new javascript asset file `turbolinks.js`
  * The new functions in `turbolinks.js` also help fix Safari header issues during redirects.
  * This asset file is added to `index.js`
  * Can we use this PR to get this file into a state where we can then add it to the Shopify App gem as an autogenerated template file as well?

##  🆕 Motivation for this prototype

I want to be able to produce the minimum amount of lines of code that partners need to run/add to their app to migrate to a Turbolinks + session token strategy. 

In the latest commit, I think this might best be accomplished by generating a new `turbolinks.js` asset file that can (optionally) be added to the `index.js` file by any partner who needs complete Turbolinks + session token + deeplinking capability. To this end, I've changed `shopify_app.js` back to the the shape of the file our default generators create.

This way, I think that our long-term session token Turbolinks strategies can be communicated in our docs as easily as:

> 1. Add `require('./turbolinks');` to `index.js`.

It also gives us a way to iterate our Turbolinks suggestions using new Shopify App releases. 
> I think we need this capability after our recent investigations into the recommended refresh interval change from 50 seconds to 2 seconds.