### PR TITLE
General improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,4 +52,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'shopify_app', '~> 16.1.0'
+gem 'shopify_app', '~> 17.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,11 +92,11 @@ GEM
       faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
-    faraday-net_http (1.0.0)
+    faraday-net_http (1.0.1)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    graphql (1.11.6)
+    graphql (1.12.2)
     graphql-client (0.16.0)
       activesupport (>= 3.0)
       graphql (~> 1.8)
@@ -186,7 +186,7 @@ GEM
     redirect_safely (1.0.0)
       activemodel
     regexp_parser (1.7.0)
-    ruby2_keywords (0.0.2)
+    ruby2_keywords (0.0.4)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
@@ -206,11 +206,11 @@ GEM
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack
-    shopify_app (16.1.0)
+    shopify_app (17.0.4)
       browser_sniffer (~> 1.2.2)
       jwt (~> 2.2.1)
       omniauth-shopify-oauth2 (~> 2.2.2)
-      rails (> 5.2.1)
+      rails (> 5.2.1, < 6.1)
       redirect_safely (~> 1.0)
       shopify_api (~> 9.1)
     sprockets (4.0.0)
@@ -264,7 +264,7 @@ DEPENDENCIES
   rails (~> 6.0.2, >= 6.0.2.2)
   sass-rails (>= 6)
   selenium-webdriver
-  shopify_app (~> 16.1.0)
+  shopify_app (~> 17.0.0)
   sqlite3 (~> 1.4)
   turbolinks (~> 5)
   tzinfo-data

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,5 +2,6 @@
 
 class HomeController < AuthenticatedController
   def index
+    @shop_origin = current_shopify_domain
   end
 end

--- a/app/javascript/shopify_app/shopify_app.js
+++ b/app/javascript/shopify_app/shopify_app.js
@@ -1,5 +1,19 @@
 import { getSessionToken } from "@shopify/app-bridge-utils";
 
+const SESSION_TOKEN_REFRESH_INTERVAL = 2000; // Request a new token every 2s
+
+document.addEventListener("turbolinks:request-start", function (event) {
+  var xhr = event.data.xhr;
+  xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
+});
+
+document.addEventListener("turbolinks:render", function () {
+  $("form, a[data-method=delete]").on("ajax:beforeSend", function (event) {
+    const xhr = event.detail[0];
+    xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
+  });
+});
+
 document.addEventListener("DOMContentLoaded", async () => {
   var data = document.getElementById("shopify-app-init").dataset;
   var AppBridge = window["app-bridge"];
@@ -18,31 +32,41 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Wait for a session token before trying to load an authenticated page
   await retrieveToken(app);
 
-  // Redirect to the requested page
-  Turbolinks.visit(data.loadPath);
-
   // Keep retrieving a session token periodically
   keepRetrievingToken(app);
-});
 
-async function retrieveToken(app) {
-  window.sessionToken = await getSessionToken(app);
-}
+  // Redirect to the requested page when DOM loads
+  var isInitialRedirect = true;
+  redirectThroughTurbolinks(isInitialRedirect);
 
-function keepRetrievingToken(app) {
-  setInterval(() => {
-    retrieveToken(app);
-  }, 50000);
-}
-
-document.addEventListener("turbolinks:request-start", function (event) {
-  var xhr = event.data.xhr;
-  xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
-});
-
-document.addEventListener("turbolinks:render", function () {
-  $("form, a[data-method=delete]").on("ajax:beforeSend", function (event) {
-    const xhr = event.detail[0];
-    xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
+  document.addEventListener("turbolinks:load", function (event) {
+    redirectThroughTurbolinks();
   });
+
+  // Helper functions
+  function redirectThroughTurbolinks(isInitialRedirect = false) {
+    var data = document.getElementById("shopify-app-init").dataset;
+    var validLoadPath = data && data.loadPath;
+    var shouldRedirect = false;
+
+    switch(isInitialRedirect) {
+      case true:
+        shouldRedirect = validLoadPath;
+        break;
+      case false:
+        shouldRedirect = validLoadPath && data.loadPath !== '/home'; // Replace with the app's home_path
+        break;
+    }
+    if (shouldRedirect) Turbolinks.visit(data.loadPath);
+  }
+
+  async function retrieveToken(app) {
+    window.sessionToken = await getSessionToken(app);
+  }
+
+  function keepRetrievingToken(app) {
+    setInterval(() => {
+      retrieveToken(app);
+    }, SESSION_TOKEN_REFRESH_INTERVAL);
+  }
 });

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,3 @@
-<%= link_to 'Products', products_path %>
+<%= link_to 'Products', products_path(shop: @shop_origin) %>
 <br>
-<%= link_to 'Widgets', widgets_path %>
+<%= link_to 'Widgets', widgets_path(shop: @shop_origin) %>


### PR DESCRIPTION
* Update the Shopify App gem to latest (17.0.4)
* Add missing shop parameters to links
* Add a turbolinks event listener to help with safari redirect issues

---

- [x] Verify that deeplinking works on Chrome, Safari, Firefox, Brave
- [x] Verify that safari header issues are fixed with this change
- [x] Verify that `shop` param is being passed in to most links to help deeplinks