### PR TITLE
Handle scope changes using shopify_app v17.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.5'
+ruby '2.7.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.2', '>= 6.0.2.2'
@@ -52,4 +52,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'shopify_app', '~> 17.0.0'
+gem 'shopify_app', '~> 17.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    graphql (1.12.2)
+    graphql (1.12.6)
     graphql-client (0.16.0)
       activesupport (>= 3.0)
       graphql (~> 1.8)
@@ -130,7 +130,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    oauth2 (1.4.4)
+    oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
@@ -202,17 +202,17 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    shopify_api (9.2.0)
+    shopify_api (9.4.0)
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack
-    shopify_app (17.0.4)
+    shopify_app (17.1.1)
       browser_sniffer (~> 1.2.2)
       jwt (~> 2.2.1)
       omniauth-shopify-oauth2 (~> 2.2.2)
       rails (> 5.2.1, < 6.1)
       redirect_safely (~> 1.0)
-      shopify_api (~> 9.1)
+      shopify_api (~> 9.4)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -264,7 +264,7 @@ DEPENDENCIES
   rails (~> 6.0.2, >= 6.0.2.2)
   sass-rails (>= 6)
   selenium-webdriver
-  shopify_app (~> 17.0.0)
+  shopify_app (~> 17.1.0)
   sqlite3 (~> 1.4)
   turbolinks (~> 5)
   tzinfo-data
@@ -273,7 +273,7 @@ DEPENDENCIES
   webpacker (~> 4.0)
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.1.4

--- a/app/controllers/splash_page_controller.rb
+++ b/app/controllers/splash_page_controller.rb
@@ -1,6 +1,7 @@
 class SplashPageController < ApplicationController
   include ShopifyApp::EmbeddedApp
   include ShopifyApp::RequireKnownShop
+  include ShopifyApp::ShopAccessScopesVerification
 
   def index
     @shop_origin = current_shopify_domain

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Shop < ActiveRecord::Base
-  include ShopifyApp::ShopSessionStorage
+  include ShopifyApp::ShopSessionStorageWithScopes
 
   def uninstall
     destroy

--- a/config/initializers/shopify_app.rb
+++ b/config/initializers/shopify_app.rb
@@ -5,6 +5,7 @@ ShopifyApp.configure do |config|
   config.old_secret = ""
   config.scope = "read_products" # Consult this page for more scope options:
                                  # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes
+  config.reauth_on_access_scope_changes = true
   config.embedded_app = true
   config.after_authenticate_job = false
   config.api_version = "2020-04"

--- a/db/migrate/20210326142533_add_shop_access_scopes_column.rb
+++ b/db/migrate/20210326142533_add_shop_access_scopes_column.rb
@@ -1,0 +1,5 @@
+class AddShopAccessScopesColumn < ActiveRecord::Migration[6.0]
+  def change
+    add_column :shops, :access_scopes, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_132720) do
+ActiveRecord::Schema.define(version: 2021_03_26_142533) do
 
   create_table "shops", force: :cascade do |t|
     t.string "shopify_domain", null: false
     t.string "shopify_token", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "access_scopes"
     t.index ["shopify_domain"], name: "index_shops_on_shopify_domain", unique: true
   end
 


### PR DESCRIPTION
* Bump ruby to v2.7.1
* Bump shopify_app to v17.1.x
* Run `rails g shopify_app:shop_model` to get access_scope column migration
* Update Shop session storage concern to be `ShopSessionStorageWithScopes`
* Configure `reauth_on_access_scope_changes = true` in shopify_app.rb
* Add the `ShopAccessScopesVerification` concern to home_controller

### Testing

1. Can verify that changing `read_products` to `write_products` prompts grant screen when navigating to the app from app list view of Admin
2. Can verify that changing `write_products` to `read_products` prompts OAuth flow when navigating to the app from app list view of Admin