### PR TITLE
allow dashes in the ngrok hostname.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,5 @@
 Rails.application.configure do
-  config.hosts = (config.hosts rescue []) << /\h+.ngrok.io/
+  config.hosts = (config.hosts rescue []) << /[\h-]+\.ngrok.io/
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on


### PR DESCRIPTION
ngrok started using dashes, in order to support hosts like this:
ae5d-75-68-33-234.ngrok.io

the hosts regex was changed to allow one or more of \h - hex digits, or a dash
[\h-]+